### PR TITLE
feat (schedule): Add a schedule screen with data from a json file

### DIFF
--- a/ZeCamp/ZeCamp.xcodeproj/project.pbxproj
+++ b/ZeCamp/ZeCamp.xcodeproj/project.pbxproj
@@ -405,11 +405,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8983662E1F2B4A73007AA57A /* ZeCamp.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = W46A5HMB5C;
-				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Debug;
 		};
@@ -417,10 +412,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8983662E1F2B4A73007AA57A /* ZeCamp.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = W46A5HMB5C;
-				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Release;
 		};

--- a/ZeCamp/ZeCamp.xcodeproj/project.pbxproj
+++ b/ZeCamp/ZeCamp.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		246199BB1F30DA1900991818 /* ScheduleScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246199BA1F30DA1900991818 /* ScheduleScreen.swift */; };
+		246199BD1F30DC1800991818 /* Schedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246199BC1F30DC1800991818 /* Schedule.swift */; };
+		24A559051F34E245009B9884 /* Sequence+groupBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24A559041F34E245009B9884 /* Sequence+groupBy.swift */; };
+		24E34C741F30EB7100076BD5 /* MyResources in Resources */ = {isa = PBXBuildFile; fileRef = 24E34C731F30EB7100076BD5 /* MyResources */; };
 		8947A42A1F2B3FF600A3E463 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8947A4291F2B3FF600A3E463 /* AppDelegate.swift */; };
 		8947A4311F2B3FF600A3E463 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8947A4301F2B3FF600A3E463 /* Assets.xcassets */; };
 		8947A4341F2B3FF600A3E463 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8947A4321F2B3FF600A3E463 /* LaunchScreen.storyboard */; };
@@ -32,6 +36,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		246199BA1F30DA1900991818 /* ScheduleScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleScreen.swift; sourceTree = "<group>"; };
+		246199BC1F30DC1800991818 /* Schedule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Schedule.swift; sourceTree = "<group>"; };
+		24A559041F34E245009B9884 /* Sequence+groupBy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sequence+groupBy.swift"; sourceTree = "<group>"; };
+		24E34C731F30EB7100076BD5 /* MyResources */ = {isa = PBXFileReference; lastKnownFileType = folder; path = MyResources; sourceTree = "<group>"; };
 		8947A4261F2B3FF600A3E463 /* ZeCamp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ZeCamp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8947A4291F2B3FF600A3E463 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8947A4301F2B3FF600A3E463 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -82,6 +90,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		246199B91F30D9E200991818 /* Schedule */ = {
+			isa = PBXGroup;
+			children = (
+				246199BA1F30DA1900991818 /* ScheduleScreen.swift */,
+				246199BC1F30DC1800991818 /* Schedule.swift */,
+			);
+			path = Schedule;
+			sourceTree = "<group>";
+		};
+		24A559031F34E1DF009B9884 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				24A559041F34E245009B9884 /* Sequence+groupBy.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		8947A41D1F2B3FF600A3E463 = {
 			isa = PBXGroup;
 			children = (
@@ -106,6 +131,9 @@
 		8947A4281F2B3FF600A3E463 /* ZeCamp */ = {
 			isa = PBXGroup;
 			children = (
+				24A559031F34E1DF009B9884 /* Extensions */,
+				24E34C731F30EB7100076BD5 /* MyResources */,
+				246199B91F30D9E200991818 /* Schedule */,
 				8947A4291F2B3FF600A3E463 /* AppDelegate.swift */,
 				8947A4301F2B3FF600A3E463 /* Assets.xcassets */,
 				8947A4321F2B3FF600A3E463 /* LaunchScreen.storyboard */,
@@ -282,6 +310,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				24E34C741F30EB7100076BD5 /* MyResources in Resources */,
 				8947A4341F2B3FF600A3E463 /* LaunchScreen.storyboard in Resources */,
 				8947A4311F2B3FF600A3E463 /* Assets.xcassets in Resources */,
 			);
@@ -308,7 +337,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				246199BB1F30DA1900991818 /* ScheduleScreen.swift in Sources */,
+				246199BD1F30DC1800991818 /* Schedule.swift in Sources */,
 				8947A42A1F2B3FF600A3E463 /* AppDelegate.swift in Sources */,
+				24A559051F34E245009B9884 /* Sequence+groupBy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -373,6 +405,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8983662E1F2B4A73007AA57A /* ZeCamp.xcconfig */;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = W46A5HMB5C;
+				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Debug;
 		};
@@ -380,6 +417,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8983662E1F2B4A73007AA57A /* ZeCamp.xcconfig */;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = W46A5HMB5C;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Release;
 		};

--- a/ZeCamp/ZeCamp/AppDelegate.swift
+++ b/ZeCamp/ZeCamp/AppDelegate.swift
@@ -10,6 +10,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window.makeKeyAndVisible()
         self.window = window
         window.rootViewController = UIViewController()
+        
+        let scheduleUrl = Bundle.main.bundleURL.appendingPathComponent("MyResources").appendingPathComponent("schedule.json")
+        
+        guard let scheduleData = try? Data(contentsOf: scheduleUrl) else {
+            return true
+        }
+        
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        
+        let schedule = try! decoder.decode(Schedule.self, from: scheduleData)
+        
+        let scheduleScreen = ScheduleScreen(schedule: schedule)
+        window.rootViewController = scheduleScreen.makeViewController()
+        
         return true
     }
 

--- a/ZeCamp/ZeCamp/Extensions/Sequence+groupBy.swift
+++ b/ZeCamp/ZeCamp/Extensions/Sequence+groupBy.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public extension Sequence {
+    func group<U: Hashable>(by key: (Iterator.Element) -> U) -> [U:[Iterator.Element]] {
+        var categories: [U: [Iterator.Element]] = [:]
+        for element in self {
+            let key = key(element)
+            if categories[key]?.append(element) == nil {
+                categories[key] = [element]
+            }
+        }
+        return categories
+    }
+}

--- a/ZeCamp/ZeCamp/MyResources/schedule.json
+++ b/ZeCamp/ZeCamp/MyResources/schedule.json
@@ -1,0 +1,34 @@
+{
+ "events": [
+            {
+            "date": "2017-09-18T09:30:00Z",
+            "durationInMinutes": 90,
+            "name": "Camp 2017 Keynote",
+            "location": "Hall 3",
+            },
+            {
+            "date": "2017-09-18T10:30:00Z",
+            "durationInMinutes": 90,
+            "name": "Camp 2017 Keynote",
+            "location": "Hall 3",
+            },
+            {
+            "date": "2017-09-18T10:30:00Z",
+            "durationInMinutes": 90,
+            "name": "Camp 2017 Keynote",
+            "location": "Hall 2",
+            },
+            {
+            "date": "2017-09-18T11:30:00Z",
+            "durationInMinutes": 90,
+            "name": "Camp 2017 Keynote",
+            "location": "Hall 3",
+            },
+            {
+            "date": "2017-09-19T09:30:00Z",
+            "durationInMinutes": 60,
+            "name": "TDD (Type Driven Development)",
+            "location": "Hall 1",
+            }
+            ]
+}

--- a/ZeCamp/ZeCamp/Schedule/Schedule.swift
+++ b/ZeCamp/ZeCamp/Schedule/Schedule.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct Event: Codable {
+    let date: Date
+    let durationInMinutes: Int
+    let name: String
+    let location: String
+}
+
+struct Schedule: Codable {
+    let events: [Event]
+}

--- a/ZeCamp/ZeCamp/Schedule/ScheduleScreen.swift
+++ b/ZeCamp/ZeCamp/Schedule/ScheduleScreen.swift
@@ -55,7 +55,9 @@ class ScheduleDataSource: NSObject, UITableViewDataSource {
     init(_ schedule: Schedule) {
         self.timeSlots = schedule.events.group(by: { $0.date }).map { date, events in
             return TimeSlot(date: date, events: events)
-        }
+        }.sorted(by: { timeSlot, otherTimeSlot in
+            return timeSlot.date.compare(otherTimeSlot.date) == ComparisonResult.orderedAscending
+        })
     }
     
     @available(iOS 2.0, *)

--- a/ZeCamp/ZeCamp/Schedule/ScheduleScreen.swift
+++ b/ZeCamp/ZeCamp/Schedule/ScheduleScreen.swift
@@ -1,0 +1,95 @@
+import Foundation
+import UIKit
+
+extension UIView {
+    func addFillingSubview(_ subview: UIView) {
+        self.addSubview(subview)
+        
+        subview.translatesAutoresizingMaskIntoConstraints = false
+        subview.topAnchor.constraint(equalTo: self.topAnchor, constant: 0).isActive = true
+        subview.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: 0).isActive = true
+        subview.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 0).isActive = true
+        subview.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: 0).isActive = true
+    }
+}
+
+struct ScheduleScreen {
+    
+    private let dataSource: UITableViewDataSource!
+    
+    init(schedule: Schedule) {
+        dataSource = ScheduleDataSource(schedule)
+    }
+    
+    func makeViewController() -> UIViewController {
+        let viewController = UIViewController()
+        let scheduleTable = ScheduleTableView()
+
+        scheduleTable.strongDataSource = dataSource
+        scheduleTable.rowHeight = UITableViewAutomaticDimension
+        scheduleTable.estimatedRowHeight = 50
+        
+        viewController.view.addFillingSubview(scheduleTable)
+        
+        return viewController
+    }
+}
+
+class ScheduleTableView: UITableView {
+    fileprivate var strongDataSource: UITableViewDataSource? {
+        didSet {
+            dataSource = strongDataSource
+        }
+    }
+}
+
+struct TimeSlot {
+    let date: Date
+    let events: [Event]
+}
+
+class ScheduleDataSource: NSObject, UITableViewDataSource {
+    
+    let timeSlots: [TimeSlot]
+    
+    init(_ schedule: Schedule) {
+        self.timeSlots = schedule.events.group(by: { $0.date }).map { date, events in
+            return TimeSlot(date: date, events: events)
+        }
+    }
+    
+    @available(iOS 2.0, *)
+    public func numberOfSections(in tableView: UITableView) -> Int {
+        return timeSlots.count
+    }
+    
+    @available(iOS 2.0, *)
+    public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return timeSlots[section].events.count
+    }
+    
+    @available(iOS 2.0, *)
+    public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return timeSlots[section].sectionTitle
+    }
+    
+    @available(iOS 2.0, *)
+    public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let event = self.timeSlots[indexPath.section].events[indexPath.row]
+        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+        
+        let label = UILabel()
+        label.text = event.name
+        cell.addFillingSubview(label)
+        return cell
+    }
+}
+
+fileprivate extension TimeSlot {
+    var sectionTitle: String {
+        //TODO: time zone?
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEEE, HH:mm"
+        return formatter.string(from: date)
+    }
+}


### PR DESCRIPTION
Pretty basic schedule screen

 - Loads the schedule from a json file
 - Groups events into time slots
 - Displays event title, start/end time and location
 - It's not pretty
 - No tests